### PR TITLE
Use bytes string instead of using encode()

### DIFF
--- a/tests/test_mets_structure.py
+++ b/tests/test_mets_structure.py
@@ -63,15 +63,15 @@ class METSStructureTests(unittest.TestCase):
         m.set_atts(attributes)
         m.add_child(mets_structure.MetsHdr())
 
-        expected_text = ('<?xml version="1.0" encoding="UTF-8"?>\n'
-                         '<mets xmlns:mets="http://www.loc.gov/METS/"'
-                         ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
-                         ' xmlns:xlink="http://www.w3.org/1999/xlink"'
-                         ' xmlns:dc="http://purl.org/dc/elements/1.1/"'
-                         ' OBJID="ark:/67531/12345">\n'
-                         '  <metsHdr/>\n'
-                         '</mets>\n')
-        self.assertEqual(m.create_xml_string(), expected_text.encode())
+        expected_text = (b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                         b'<mets xmlns:mets="http://www.loc.gov/METS/"'
+                         b' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+                         b' xmlns:xlink="http://www.w3.org/1999/xlink"'
+                         b' xmlns:dc="http://purl.org/dc/elements/1.1/"'
+                         b' OBJID="ark:/67531/12345">\n'
+                         b'  <metsHdr/>\n'
+                         b'</mets>\n')
+        self.assertEqual(m.create_xml_string(), expected_text)
 
 
 def suite():

--- a/tests/test_metsdoc.py
+++ b/tests/test_metsdoc.py
@@ -7,11 +7,11 @@ from pymets import metsdoc
 class METSDocTests(unittest.TestCase):
 
     def test_invalid_mets_element(self):
-        mets_string = """<?xml version="1.0" encoding="UTF-8"?>
+        mets_string = b"""<?xml version="1.0" encoding="UTF-8"?>
         <mets><metsHDR/></mets>"""
 
         with self.assertRaises(metsdoc.PymetsException) as cm:
-            metsdoc.metsxml2py(io.BytesIO(mets_string.encode('utf-8')))
+            metsdoc.metsxml2py(io.BytesIO(mets_string))
 
         expected_error = 'Element "metsHDR" not found in mets dispatch.'
         self.assertEqual(str(cm.exception), expected_error)


### PR DESCRIPTION
@somexpert @ldko 
A very minor change to use bytes string in tests instead of using encode()

Also, wondering if we need to add installation and testing sections in README (to the master)?