### PR TITLE
Update version for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pymets',
-    version='1.0.0',
+    version='2.0.0',
     description='Python module for reading and writing METS files.',
     author='University of North Texas Libraries',
     author_email='mark.phillips@unt.edu',


### PR DESCRIPTION
We never updated the version when we upgraded from Python 2 to Python 3 support. I would like to change this, so I can tag the Python 2 version and not feel odd about it having 1.0.0 version in setup, same as Python 3.

ping @somexpert @madhulika95b Let me know if you have any thoughts against doing this...