### PR TITLE
Not using dc namespace in our METS files

### DIFF
--- a/pymets/__init__.py
+++ b/pymets/__init__.py
@@ -3,7 +3,6 @@ NSMAP = {
     'mets': 'http://www.loc.gov/METS/',
     'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
     'xlink': 'http://www.w3.org/1999/xlink',
-    'dc': 'http://purl.org/dc/elements/1.1/',
     }
 
 # Create the prependable xsi namespace.

--- a/tests/test_mets_structure.py
+++ b/tests/test_mets_structure.py
@@ -67,7 +67,6 @@ class METSStructureTests(unittest.TestCase):
                          b'<mets xmlns:mets="http://www.loc.gov/METS/"'
                          b' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
                          b' xmlns:xlink="http://www.w3.org/1999/xlink"'
-                         b' xmlns:dc="http://purl.org/dc/elements/1.1/"'
                          b' OBJID="ark:/67531/12345">\n'
                          b'  <metsHdr/>\n'
                          b'</mets>\n')


### PR DESCRIPTION
We do not include Dublin Core metadata in the METS files we generate for our AIPs and ACPs, so we don't need to list the `dc` namespace in the XML document we generate.

@somexpert @madhulika95b this very small PR is ready for review.