### PR TITLE
Allow metsDocumentID on metsHdr elements

### DIFF
--- a/pymets/mets_structure.py
+++ b/pymets/mets_structure.py
@@ -186,7 +186,7 @@ class Mets(MetsBase):
 class MetsHdr(MetsBase):
     """Wrapper for metsHdr element."""
     tag = "metsHdr"
-    contained_children = ["agent",  "altRecordID"]
+    contained_children = ["agent",  "altRecordID", "metsDocumentID"]
 
     def __init__(self, **kwargs):
         self.atts = {
@@ -227,6 +227,15 @@ class AltRecordID(MetsBase):
     def __init__(self, **kwargs):
         self.atts = {"TYPE": None}
         super(AltRecordID, self).__init__(**kwargs)
+
+
+class MetsDocumentID(MetsBase):
+    tag = "metsDocumentID"
+    allows_content = True
+
+    def __init__(self, **kwargs):
+        self.atts = {"TYPE": None}
+        super(MetsDocumentID, self).__init__(**kwargs)
 
 
 class DmdSec(MetsBase):

--- a/pymets/metsdoc.py
+++ b/pymets/metsdoc.py
@@ -27,6 +27,7 @@ PYMETS_DISPATCH = {
     'name': mets_structure.Name,
     'note': mets_structure.Note,
     'altRecordID': mets_structure.AltRecordID,
+    'metsDocumentID': mets_structure.MetsDocumentID,
     'dmdSec': mets_structure.DmdSec,
     'mdRef': mets_structure.MdRef,
     'amdSec': mets_structure.AmdSec,

--- a/tests/test_mets_structure.py
+++ b/tests/test_mets_structure.py
@@ -61,14 +61,21 @@ class METSStructureTests(unittest.TestCase):
 
         m = mets_structure.Mets()
         m.set_atts(attributes)
-        m.add_child(mets_structure.MetsHdr())
+        hdr = mets_structure.MetsHdr()
+        doc_id = mets_structure.MetsDocumentID(content='12345.aip.2018-05-07T23:29:05Z',
+                                               attributes={'TYPE': 'AIP-Version-Identifier'})
+        hdr.add_child(doc_id)
+        m.add_child(hdr)
 
         expected_text = (b'<?xml version="1.0" encoding="UTF-8"?>\n'
                          b'<mets xmlns:mets="http://www.loc.gov/METS/"'
                          b' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
                          b' xmlns:xlink="http://www.w3.org/1999/xlink"'
                          b' OBJID="ark:/67531/12345">\n'
-                         b'  <metsHdr/>\n'
+                         b'  <metsHdr>\n'
+                         b'    <metsDocumentID TYPE="AIP-Version-Identifier">'
+                         b'12345.aip.2018-05-07T23:29:05Z</metsDocumentID>\n'
+                         b'  </metsHdr>\n'
                          b'</mets>\n')
         self.assertEqual(m.create_xml_string(), expected_text)
 


### PR DESCRIPTION
We are going to be adding [`metsDocumentID` elements](http://www.loc.gov/standards/mets/docs/mets.v1-9.html#metsDocumentID) to our ACP METS files. Thus, we need to allow them in our pymets structure. This adds that ability.

This is ready for review @somexpert @madhulika95b .